### PR TITLE
Remove another 1% of the code

### DIFF
--- a/almost_sinatra.rb
+++ b/almost_sinatra.rb
@@ -1,4 +1,4 @@
-%w.rack tilt backports INT TERM..map{|l|trap(l){$r.stop}rescue require l}
+%w.rack tilt INT TERM..map{|l|trap(l){$r.stop}rescue require l}
 $n=Sinatra=Module.new{extend Rack;a,D,S,$p,q,Application=Builder.new,Object.method(:define_method),/@@ *([^\n]+)\n(((?!@@)[^\n]*\n)*)/m,4567,a
 %w[get post put delete].map{|m|D.(m){|u,&b|a.map(u){run->(e){[200,{"Content-Type"=>"text/html"},[a.instance_eval(&b)]]}}}}
 Tilt.mappings.map{|k,v|D.(k){|n,*o|$t||=(h={};File.read(caller[0][/^[^:]+/]).scan(S){|a,b|h[a]=b};h);v[0].new(*o){n.to_s==n ?n:$t[n.to_s]}.render(a,o[0].try(:[],:locals)||{})}}


### PR DESCRIPTION
Since the syntax depends on 1.9 mode, we can remove this dependency.
This saves us another 10 bytes from the source which is over 1% of the
entire almost Sinatra codebase.

I of course haven't tested this change, for that we have users to
verify that it works.
