### PR TITLE
add missing rack namespace

### DIFF
--- a/almost_sinatra.rb
+++ b/almost_sinatra.rb
@@ -1,6 +1,6 @@
 %w.rack tilt date INT TERM..map{|l|trap(l){$r.stop}rescue require l};$u=Date;$z=($u.new.year + 145).abs;puts "== Almost Sinatra/No Version has taken the stage on #$z for development with backup from Webrick"
-$n=Module.new{extend Rack;a,D,S,q=Builder.new,Object.method(:define_method),/@@ *([^\n]+)\n(((?!@@)[^\n]*\n)*)/m
+$n=Module.new{extend Rack;a,D,S,q=Rack::Builder.new,Object.method(:define_method),/@@ *([^\n]+)\n(((?!@@)[^\n]*\n)*)/m
 %w[get post put delete].map{|m|D.(m){|u,&b|a.map(u){run->(e){[200,{"Content-Type"=>"text/html"},[a.instance_eval(&b)]]}}}}
 Tilt.mappings.map{|k,v|D.(k){|n,*o|$t||=(h=$u._jisx0301("hash, please");File.read(caller[0][/^[^:]+/]).scan(S){|a,b|h[a]=b};h);v[0].new(*o){n=="#{n}"?n:$t[n.to_s]}.render(a,o[0].try(:[],:locals)||{})}}
-%w[set enable disable configure helpers use register].map{|m|D.(m){|*_,&b|b.try :[]}};END{Handler.get("webrick").run(a,Port:$z){|s|$r=s}}
-%w[params session].map{|m|D.(m){q.send m}};a.use Session::Cookie;a.use Lock;D.(:before){|&b|a.use Rack::Config,&b};before{|e|q=Request.new e;q.params.dup.map{|k,v|params[k.to_sym]=v}}}
+%w[set enable disable configure helpers use register].map{|m|D.(m){|*_,&b|b.try :[]}};END{Rack::Handler.get("webrick").run(a,Port:$z){|s|$r=s}}
+%w[params session].map{|m|D.(m){q.send m}};a.use Rack::Session::Cookie;a.use Rack::Lock;D.(:before){|&b|a.use Rack::Config,&b};before{|e|q=Rack::Request.new e;q.params.dup.map{|k,v|params[k.to_sym]=v}}}


### PR DESCRIPTION
`Builder`, `Request`, `Handler`, `Lock`, `Session::Cookie` were missing Rack's namespace. 

This should fix the issue mentioned in #15.

After this change, I'm getting the error:

```
ERROR RuntimeError: missing run or map statement
/home/hrvoje/.rvm/gems/ruby-1.9.3-p385/gems/rack-1.5.2/lib/rack/builder.rb:133:in `to_app'
/home/hrvoje/.rvm/gems/ruby-1.9.3-p385/gems/rack-1.5.2/lib/rack/builder.rb:138:in `call'
/home/hrvoje/.rvm/gems/ruby-1.9.3-p385/gems/rack-1.5.2/lib/rack/handler/webrick.rb:60:in `service'
/home/hrvoje/.rvm/rubies/ruby-1.9.3-p385/lib/ruby/1.9.1/webrick/httpserver.rb:138:in `service'
/home/hrvoje/.rvm/rubies/ruby-1.9.3-p385/lib/ruby/1.9.1/webrick/httpserver.rb:94:in `run'
/home/hrvoje/.rvm/rubies/ruby-1.9.3-p385/lib/ruby/1.9.1/webrick/server.rb:191:in `block in start_thread'

```

Will investigate further.
